### PR TITLE
Use ansible omnibus on Ubuntu boxes

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -10,7 +10,7 @@ provisioner:
   ansible_version: latest
   require_ruby_for_busser: true
   group_vars_path: local
-  require_chef_for_busser: false
+  require_chef_for_busser: False
 
 transport:
   max_ssh_sessions: 6
@@ -21,12 +21,29 @@ busser:
 
 platforms:
   - name: trusty
+    provisioner:
+      ansible_version: 2.2.0.0
+      require_ansible_omnibus: True
+      ansible_omnibus_url: https://raw.githubusercontent.com/neillturner/omnibus-ansible/master/ansible_install.sh
+
     driver_config:
       box: ubuntu/trusty64
 
   - name: xenial
+    provisioner:
+      ansible_version: 2.2.0.0
+      require_ansible_omnibus: True
+      ansible_omnibus_url: https://raw.githubusercontent.com/neillturner/omnibus-ansible/master/ansible_install.sh
     driver_config:
       box: ubuntu/xenial64
+
+  - name: jessie
+    provisioner:
+      ansible_version: 2.2.0.0
+      require_ansible_omnibus: True
+      ansible_omnibus_url: https://raw.githubusercontent.com/neillturner/omnibus-ansible/master/ansible_install.sh
+    driver_config:
+      box: debian/jessie64
 
   - name: centos7
     driver_config:


### PR DESCRIPTION
Following up on the [issue](https://github.com/neillturner/kitchen-ansible/issues/227) reported on the official [Ansible Kitchen repo](https://github.com/neillturner/kitchen-ansible), Ansible will be installed using `ansible_omnibus` on the following boxes:

* trusty (Ubuntu-14.04)
* xenial (Ubuntu-16.04)
* jessie (Debian-8)